### PR TITLE
DDT-16: Basic scaffolding for receiving notifications

### DIFF
--- a/src/main/java/org/dcsa/ovs/controller/NotificationEndpointController.java
+++ b/src/main/java/org/dcsa/ovs/controller/NotificationEndpointController.java
@@ -1,0 +1,76 @@
+package org.dcsa.ovs.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.dcsa.core.controller.ExtendedBaseController;
+import org.dcsa.core.events.service.impl.MessageSignatureHandler;
+import org.dcsa.ovs.model.NotificationEndpoint;
+import org.dcsa.ovs.service.NotificationEndpointService;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+import reactor.core.publisher.Mono;
+
+import java.util.Map;
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping(value = "unofficial/notification-endpoints", produces = {MediaType.APPLICATION_JSON_VALUE})
+@Slf4j
+public class NotificationEndpointController extends ExtendedBaseController<NotificationEndpointService, NotificationEndpoint, UUID> {
+
+    private final NotificationEndpointService notificationEndpointService;
+    private final MessageSignatureHandler messageSignatureHandler;
+
+    @Override
+    public NotificationEndpointService getService() {
+        return notificationEndpointService;
+    }
+
+    @RequestMapping(
+            path = "receive/{id}",
+            method = {
+                    RequestMethod.POST,
+                    RequestMethod.HEAD
+            }
+    )
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public Mono<Void> receivePayload(ServerHttpRequest request, @PathVariable("id") UUID endpointID) {
+        return notificationEndpointService.findById(endpointID)
+                .flatMap(notificationEndpoint -> {
+                    String subscriptionID = notificationEndpoint.getSubscriptionID();
+                    if (request.getMethod() == HttpMethod.HEAD) {
+                        // verify request - we are happy at this point. (note that we forgive missing subscriptionIDs
+                        // as the endpoint can be verified before we know the Subscription ID)
+                        return Mono.empty();
+                    }
+                    if (subscriptionID == null) {
+                        // We do not have a subscription ID yet. Assume that it is not a match
+                        // Ideally, we would include a "Retry-After" header as well.
+                        return Mono.error(new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE));
+                    }
+                    return messageSignatureHandler.verifyRequest(request,
+                            notificationEndpoint.getSubscriptionID(),
+                            notificationEndpoint.getSecret(),
+                            Map.class);
+                }).flatMap(signatureResult -> {
+                    if (!signatureResult.isValid()) {
+                        // The unconditional usage of UNAUTHORIZED is deliberate. We are not interested in letting
+                        // the caller know why we are rejecting - just that we are not happy.  Telling more might
+                        // inform them of a bug or enable them to guess part of the secret.
+                        log.debug("Rejecting message because: " + signatureResult.getResult());
+                        return Mono.error(new ResponseStatusException(HttpStatus.UNAUTHORIZED));
+                    }
+                    // TODO: Implement as a part of DDT-114 using signatureResult.getParsed() and return "Mono.empty()"
+                    // (or end with .then())
+                    // Remember you can change the 4th parameter of "verifyRequest" above to change the type of
+                    // value returned by getParsed (it might require changes if you want to support complex
+                    // types)
+                    return Mono.error(new ResponseStatusException(HttpStatus.NOT_IMPLEMENTED));
+                }).then();
+    }
+}

--- a/src/main/java/org/dcsa/ovs/controller/NotificationEndpointController.java
+++ b/src/main/java/org/dcsa/ovs/controller/NotificationEndpointController.java
@@ -3,18 +3,14 @@ package org.dcsa.ovs.controller;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.dcsa.core.controller.ExtendedBaseController;
-import org.dcsa.core.events.service.impl.MessageSignatureHandler;
 import org.dcsa.ovs.model.NotificationEndpoint;
 import org.dcsa.ovs.service.NotificationEndpointService;
-import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.server.ResponseStatusException;
 import reactor.core.publisher.Mono;
 
-import java.util.Map;
 import java.util.UUID;
 
 @RestController
@@ -24,7 +20,6 @@ import java.util.UUID;
 public class NotificationEndpointController extends ExtendedBaseController<NotificationEndpointService, NotificationEndpoint, UUID> {
 
     private final NotificationEndpointService notificationEndpointService;
-    private final MessageSignatureHandler messageSignatureHandler;
 
     @Override
     public NotificationEndpointService getService() {
@@ -40,37 +35,6 @@ public class NotificationEndpointController extends ExtendedBaseController<Notif
     )
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public Mono<Void> receivePayload(ServerHttpRequest request, @PathVariable("id") UUID endpointID) {
-        return notificationEndpointService.findById(endpointID)
-                .flatMap(notificationEndpoint -> {
-                    String subscriptionID = notificationEndpoint.getSubscriptionID();
-                    if (request.getMethod() == HttpMethod.HEAD) {
-                        // verify request - we are happy at this point. (note that we forgive missing subscriptionIDs
-                        // as the endpoint can be verified before we know the Subscription ID)
-                        return Mono.empty();
-                    }
-                    if (subscriptionID == null) {
-                        // We do not have a subscription ID yet. Assume that it is not a match
-                        // Ideally, we would include a "Retry-After" header as well.
-                        return Mono.error(new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE));
-                    }
-                    return messageSignatureHandler.verifyRequest(request,
-                            notificationEndpoint.getSubscriptionID(),
-                            notificationEndpoint.getSecret(),
-                            Map.class);
-                }).flatMap(signatureResult -> {
-                    if (!signatureResult.isValid()) {
-                        // The unconditional usage of UNAUTHORIZED is deliberate. We are not interested in letting
-                        // the caller know why we are rejecting - just that we are not happy.  Telling more might
-                        // inform them of a bug or enable them to guess part of the secret.
-                        log.debug("Rejecting message because: " + signatureResult.getResult());
-                        return Mono.error(new ResponseStatusException(HttpStatus.UNAUTHORIZED));
-                    }
-                    // TODO: Implement as a part of DDT-114 using signatureResult.getParsed() and return "Mono.empty()"
-                    // (or end with .then())
-                    // Remember you can change the 4th parameter of "verifyRequest" above to change the type of
-                    // value returned by getParsed (it might require changes if you want to support complex
-                    // types)
-                    return Mono.error(new ResponseStatusException(HttpStatus.NOT_IMPLEMENTED));
-                }).then();
+        return notificationEndpointService.receiveNotification(request, endpointID);
     }
 }

--- a/src/main/java/org/dcsa/ovs/model/NotificationEndpoint.java
+++ b/src/main/java/org/dcsa/ovs/model/NotificationEndpoint.java
@@ -1,0 +1,26 @@
+package org.dcsa.ovs.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Column;
+import org.springframework.data.relational.core.mapping.Table;
+
+import java.util.UUID;
+
+@Table("notification_endpoint")
+@Data
+public class NotificationEndpoint {
+
+    @Id
+    @Column("endpoint_id")
+    private UUID endpointID;
+
+    @Column("subscription_id")
+    private String subscriptionID;
+
+    @Column("secret")
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    private byte[] secret;
+
+}

--- a/src/main/java/org/dcsa/ovs/repository/NotificationEndpointRepository.java
+++ b/src/main/java/org/dcsa/ovs/repository/NotificationEndpointRepository.java
@@ -1,0 +1,9 @@
+package org.dcsa.ovs.repository;
+
+import org.dcsa.core.repository.ExtendedRepository;
+import org.dcsa.ovs.model.NotificationEndpoint;
+
+import java.util.UUID;
+
+public interface NotificationEndpointRepository extends ExtendedRepository<NotificationEndpoint, UUID> {
+}

--- a/src/main/java/org/dcsa/ovs/service/NotificationEndpointService.java
+++ b/src/main/java/org/dcsa/ovs/service/NotificationEndpointService.java
@@ -2,9 +2,13 @@ package org.dcsa.ovs.service;
 
 import org.dcsa.core.service.ExtendedBaseService;
 import org.dcsa.ovs.model.NotificationEndpoint;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.web.bind.annotation.PathVariable;
+import reactor.core.publisher.Mono;
 
 import java.util.UUID;
 
 public interface NotificationEndpointService extends ExtendedBaseService<NotificationEndpoint, UUID> {
 
+    Mono<Void> receiveNotification(ServerHttpRequest request, UUID endpointID);
 }

--- a/src/main/java/org/dcsa/ovs/service/NotificationEndpointService.java
+++ b/src/main/java/org/dcsa/ovs/service/NotificationEndpointService.java
@@ -1,0 +1,10 @@
+package org.dcsa.ovs.service;
+
+import org.dcsa.core.service.ExtendedBaseService;
+import org.dcsa.ovs.model.NotificationEndpoint;
+
+import java.util.UUID;
+
+public interface NotificationEndpointService extends ExtendedBaseService<NotificationEndpoint, UUID> {
+
+}

--- a/src/main/java/org/dcsa/ovs/service/impl/NotificationEndpointServiceImpl.java
+++ b/src/main/java/org/dcsa/ovs/service/impl/NotificationEndpointServiceImpl.java
@@ -1,0 +1,52 @@
+package org.dcsa.ovs.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.dcsa.core.events.model.enums.SignatureMethod;
+import org.dcsa.core.exception.CreateException;
+import org.dcsa.core.exception.GetException;
+import org.dcsa.core.service.impl.ExtendedBaseServiceImpl;
+import org.dcsa.ovs.model.NotificationEndpoint;
+import org.dcsa.ovs.repository.NotificationEndpointRepository;
+import org.dcsa.ovs.service.NotificationEndpointService;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+import java.util.UUID;
+
+@RequiredArgsConstructor
+@Service
+public class NotificationEndpointServiceImpl extends ExtendedBaseServiceImpl<NotificationEndpointRepository, NotificationEndpoint, UUID> implements NotificationEndpointService {
+
+    private final NotificationEndpointRepository notificationEndpointRepository;
+
+    @Override
+    protected Mono<NotificationEndpoint> preSaveHook(NotificationEndpoint notificationEndpoint) {
+        SignatureMethod method = SignatureMethod.HMAC_SHA256;
+        byte[] secret = notificationEndpoint.getSecret();
+        if (secret == null) {
+            return Mono.error(new CreateException("Missing mandatory secret field"));
+        }
+        if (secret.length < method.getMinKeyLength()) {
+            return Mono.error(new CreateException("length of the secret should be minimum " + method.getMinKeyLength()
+                    + " bytes long (was: " + secret.length + ")"));
+        }
+        if (method.getMaxKeyLength() < secret.length) {
+            return Mono.error(new CreateException("length of the secret should be maximum " + method.getMinKeyLength()
+                    + " bytes long (was: " + secret.length + ")"));
+        }
+        return super.preSaveHook(notificationEndpoint);
+    }
+
+    @Override
+    protected Mono<NotificationEndpoint> preUpdateHook(NotificationEndpoint original, NotificationEndpoint update) {
+        if (update.getSecret() == null) {
+            update.setSecret(original.getSecret());
+        }
+        return super.preUpdateHook(original, update);
+    }
+
+    @Override
+    public NotificationEndpointRepository getRepository() {
+        return notificationEndpointRepository;
+    }
+}

--- a/src/main/java/org/dcsa/ovs/service/impl/NotificationEndpointServiceImpl.java
+++ b/src/main/java/org/dcsa/ovs/service/impl/NotificationEndpointServiceImpl.java
@@ -2,15 +2,20 @@ package org.dcsa.ovs.service.impl;
 
 import lombok.RequiredArgsConstructor;
 import org.dcsa.core.events.model.enums.SignatureMethod;
+import org.dcsa.core.events.service.impl.MessageSignatureHandler;
 import org.dcsa.core.exception.CreateException;
-import org.dcsa.core.exception.GetException;
 import org.dcsa.core.service.impl.ExtendedBaseServiceImpl;
 import org.dcsa.ovs.model.NotificationEndpoint;
 import org.dcsa.ovs.repository.NotificationEndpointRepository;
 import org.dcsa.ovs.service.NotificationEndpointService;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 import reactor.core.publisher.Mono;
 
+import java.util.Map;
 import java.util.UUID;
 
 @RequiredArgsConstructor
@@ -18,6 +23,7 @@ import java.util.UUID;
 public class NotificationEndpointServiceImpl extends ExtendedBaseServiceImpl<NotificationEndpointRepository, NotificationEndpoint, UUID> implements NotificationEndpointService {
 
     private final NotificationEndpointRepository notificationEndpointRepository;
+    private final MessageSignatureHandler messageSignatureHandler;
 
     @Override
     protected Mono<NotificationEndpoint> preSaveHook(NotificationEndpoint notificationEndpoint) {
@@ -48,5 +54,41 @@ public class NotificationEndpointServiceImpl extends ExtendedBaseServiceImpl<Not
     @Override
     public NotificationEndpointRepository getRepository() {
         return notificationEndpointRepository;
+    }
+
+    @Override
+    public Mono<Void> receiveNotification(ServerHttpRequest request, UUID endpointID) {
+        return findById(endpointID)
+                .flatMap(notificationEndpoint -> {
+                    String subscriptionID = notificationEndpoint.getSubscriptionID();
+                    if (request.getMethod() == HttpMethod.HEAD) {
+                        // verify request - we are happy at this point. (note that we forgive missing subscriptionIDs
+                        // as the endpoint can be verified before we know the Subscription ID)
+                        return Mono.empty();
+                    }
+                    if (subscriptionID == null) {
+                        // We do not have a subscription ID yet. Assume that it is not a match
+                        // Ideally, we would include a "Retry-After" header as well.
+                        return Mono.error(new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE));
+                    }
+                    return messageSignatureHandler.verifyRequest(request,
+                            notificationEndpoint.getSubscriptionID(),
+                            notificationEndpoint.getSecret(),
+                            Map.class);
+                }).flatMap(signatureResult -> {
+                    if (!signatureResult.isValid()) {
+                        // The unconditional usage of UNAUTHORIZED is deliberate. We are not interested in letting
+                        // the caller know why we are rejecting - just that we are not happy.  Telling more might
+                        // inform them of a bug or enable them to guess part of the secret.
+                        log.debug("Rejecting message because: " + signatureResult.getResult());
+                        return Mono.error(new ResponseStatusException(HttpStatus.UNAUTHORIZED));
+                    }
+                    // TODO: Implement as a part of DDT-114 using signatureResult.getParsed() and return "Mono.empty()"
+                    // (or end with .then())
+                    // Remember you can change the 4th parameter of "verifyRequest" above to change the type of
+                    // value returned by getParsed (it might require changes if you want to support complex
+                    // types)
+                    return Mono.error(new ResponseStatusException(HttpStatus.NOT_IMPLEMENTED));
+                }).then();
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -54,6 +54,10 @@ springdoc:
     # swagger-ui custom path
     path: /docs
 
+dcsa:
+  securityConfig:
+    receiveNotificationEndpoint: "/unofficial/notification-endpoints"
+
 server:
   port: 9090
   error:
@@ -63,4 +67,6 @@ server:
 logging:
   level:
     dk: DEBUG
+    org:
+      dcsa: DEBUG
 


### PR DESCRIPTION
This prepares OVS for receiving notifications from another OVS (or
TNT) instance.  The flow for this is:

 1) Client creates a NotificationEndpoint by posting to
    `https://hostname/v2/unofficial/notification-endpoints` with a
    secret.  The response will include a `endpointID`.

 2) Using the `endpointID`, the Client can generate the callback URL:
    `https://hostname/v2/unofficial/notification-endpoints/receive/<endpointID>`

 3) The Client then creates a subscription in the external system with
    that callback URL and the secret.  On success, the external system
    will provide the caller with a `subscriptionID`

 4) The client then updates the NotificationEndpoint to provide the
    SubscriptionID.  This is a standard PUT call to
    `https://hostname/v2/unofficial/notification-endpoints/<endpointID>`
    (The secret can be omitted)

After point 4), the callbackURL from step 2) will start to accept
notifications.  The code for validating the signature is in place.
But the code for understanding the payload is missing and the endpoint
will therefore return `501 Not Implemented` until DDT-114 is fixed.

Signed-off-by: Niels Thykier <nt@asseco.dk>